### PR TITLE
Raspberry PI device tree overrides

### DIFF
--- a/src/plat/bcm2711/overlay-rpi4-address-mapping.dts
+++ b/src/plat/bcm2711/overlay-rpi4-address-mapping.dts
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2021, Hensoldt Cyber GmbH
+ * Copyright 2022, Technology Innovation Institute
  *
  * SPDX-License-Identifier: GPL-2.0-only
  */
@@ -17,6 +18,13 @@
 	 * addresses in this overlay file.
 	 */
 	soc {
+		timer@7e003000 {
+			reg = <0xfe003000 0x1000>;
+			/* Channels 0 and 2 used by VC, so just expose 1 and
+			 * 3. Otherwise we're spammed with spurious
+			 * interrupts. */
+			interrupts = <0x00 0x41 0x04 0x00 0x43 0x04>;
+		};
 
 		serial@7e201400 {
 			reg = <0xfe201400 0x200>;

--- a/src/plat/bcm2837/overlay-rpi3.dts
+++ b/src/plat/bcm2837/overlay-rpi3.dts
@@ -41,4 +41,14 @@
 			no-map;
 		};
 	};
+
+        soc {
+                timer@7e003000 {
+                        reg = <0x3F003000 0x1000>;
+			/* Channels 0 and 2 used by VC, so just expose 1 and
+			 * 3. Otherwise we're spammed with spurious
+			 * interrupts. */
+                        interrupts = <0x01 0x01 0x01 0x03>;
+                };
+        };
 };


### PR DESCRIPTION
Translate system timer addresses for user space timer drives. Remove channel 0 and 2 IRQs, which are reserved for VideoCore, to avoid spurious interrupts.