### PR TITLE
cmake: support supplying custom device trees

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,8 @@ include(${KERNEL_FLAGS_PATH})
 
 add_compile_options(
     -std=c99
+    -finstrument-functions
+    -finstrument-functions-exclude-function-list=__cyg_profile_func_enter,__cyg_profile_func_exit,getCurrentCPUIndex
     #-----------------------------------
     # Configure warnings
     #-----------------------------------
@@ -687,3 +689,4 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
     install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/libsel4/src/" DESTINATION libsel4/src)
 
 endif()
+

--- a/config.cmake
+++ b/config.cmake
@@ -94,6 +94,17 @@ include(src/arch/${KernelArch}/config.cmake)
 include(include/${KernelWordSize}/mode/config.cmake)
 include(src/config.cmake)
 
+set(KernelCustomDTS "" CACHE FILEPATH "Provide a device tree file to use instead of the \
+KernelPlatform's defaults")
+
+if(NOT "${KernelCustomDTS}" STREQUAL "")
+    if(NOT EXISTS ${KernelCustomDTS})
+        message(FATAL_ERROR "Can't open external dts file '${KernelCustomDTS}'!")
+    endif()
+    # Override list to hold only custom dts
+    set(KernelDTSList "${KernelCustomDTS}")
+endif()
+
 if(DEFINED KernelDTSList AND (NOT "${KernelDTSList}" STREQUAL ""))
     set(KernelDTSIntermediate "${CMAKE_CURRENT_BINARY_DIR}/kernel.dts")
     set(

--- a/include/arch/arm/armv/armv8-a/64/armv/vcpu.h
+++ b/include/arch/arm/armv/armv8-a/64/armv/vcpu.h
@@ -19,7 +19,7 @@
 #define HCR_COMMON ( HCR_VM | HCR_RW | HCR_AMO | HCR_IMO | HCR_FMO )
 #else
 /* Trap WFI/WFE/SMC and override CPSR.AIF */
-#define HCR_COMMON ( HCR_TWI | HCR_TWE | HCR_VM | HCR_RW | HCR_AMO | HCR_IMO | HCR_FMO )
+#define HCR_COMMON ( HCR_TWI | /*HCR_TWE |*/ HCR_VM | HCR_RW | HCR_AMO | HCR_IMO | HCR_FMO )
 #endif
 
 /* Allow native tasks to run at EL0, but restrict access */
@@ -46,6 +46,7 @@
 #define SCTLR_DEFAULT      SCTLR_EL1_NATIVE
 
 #define UNKNOWN_FAULT       0x2000000
+#define ESR_EC_WFX          0x1         /* Trap WFI and WFE */
 #define ESR_EC_TFP          0x7         /* Trap instructions that access FPU registers */
 #define ESR_EC_CPACR        0x18        /* Trap access to CPACR                        */
 #define ESR_EC(x)           (((x) & 0xfc000000) >> 26)
@@ -655,6 +656,13 @@ static inline bool_t armv_handleVCPUFault(word_t hsr)
         return true;
     }
 #endif
+    if (ESR_EC(hsr) == ESR_EC_WFX) {
+        if ((hsr & 1) == 0) {
+            /* WFI */
+            handleSyscall(SysYield);
+            return true;
+        }
+    }
 
     if (hsr == UNKNOWN_FAULT) {
         handleUserLevelFault(getESR(), 0);

--- a/src/config.cmake
+++ b/src/config.cmake
@@ -20,6 +20,7 @@ add_sources(
         src/kernel/thread.c
         src/kernel/boot.c
         src/kernel/stack.c
+        src/kernel/trace.c
         src/object/notification.c
         src/object/cnode.c
         src/object/endpoint.c

--- a/src/kernel/trace.c
+++ b/src/kernel/trace.c
@@ -1,0 +1,26 @@
+#include <mode/smp/smp.h>
+#include <arch/machine.h>
+
+typedef struct {
+	unsigned long func;
+} trace_entry_t;
+
+unsigned int te_head[CONFIG_MAX_NUM_NODES] = {0};
+trace_entry_t tes[CONFIG_MAX_NUM_NODES][1024];
+
+void __cyg_profile_func_enter(void *thisfn, void *call_site)
+{
+#ifdef ENABLE_SMP_SUPPORT
+	int cpu = getCurrentCPUIndex();
+#else
+	int cpu = 0;
+#endif
+	tes[cpu][te_head[cpu]].func = (unsigned long) thisfn;
+	te_head[cpu]++;
+	te_head[cpu] &= 1023;
+	__asm__ volatile ("dsb sy");
+}
+
+void __cyg_profile_func_exit(void *thisfn, void *call_site)
+{
+}

--- a/src/plat/bcm2711/overlay-rpi4-address-mapping.dts
+++ b/src/plat/bcm2711/overlay-rpi4-address-mapping.dts
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2021, Hensoldt Cyber GmbH
+ * Copyright 2022, Technology Innovation Institute
  *
  * SPDX-License-Identifier: GPL-2.0-only
  */
@@ -17,6 +18,13 @@
 	 * addresses in this overlay file.
 	 */
 	soc {
+		timer@7e003000 {
+			reg = <0xfe003000 0x1000>;
+			/* Channels 0 and 2 used by VC, so just expose 1 and
+			 * 3. Otherwise we're spammed with spurious
+			 * interrupts. */
+			interrupts = <0x00 0x41 0x04 0x00 0x43 0x04>;
+		};
 
 		serial@7e201400 {
 			reg = <0xfe201400 0x200>;

--- a/src/plat/bcm2711/overlay-rpi4-address-mapping.dts
+++ b/src/plat/bcm2711/overlay-rpi4-address-mapping.dts
@@ -17,9 +17,6 @@
 	 * addresses in this overlay file.
 	 */
 	soc {
-		gpio@7e200000 {
-			reg = <0xfe200000 0xb4>;
-		};
 
 		serial@7e201400 {
 			reg = <0xfe201400 0x200>;

--- a/src/plat/bcm2711/overlay-rpi4.dts
+++ b/src/plat/bcm2711/overlay-rpi4.dts
@@ -91,7 +91,7 @@
 		 * use the VideoCore memory area
 		 * by declaring it as reserved memory.
 		 */
-		reserved-memory@3c000000 {
+		reserved-memory@3b400000 {
 			reg = < 0x00000000 0x3b400000 0x04C00000 >;
 			no-map;
 		};

--- a/src/plat/bcm2711/overlay-rpi4.dts
+++ b/src/plat/bcm2711/overlay-rpi4.dts
@@ -18,8 +18,28 @@
 	};
 
 	memory@0 {
-		/* This is configurable in the Pi's config.txt, but we use 128MiB of RAM by default. */
-		reg = <0x00 0x00000000 0x08000000>;
+        /*
+         * See BCM2711 TRM section 1.2 and
+         * https://github.com/raspberrypi/firmware/issues/1374 for
+         * reference.
+         */
+
+         /* RPi4B seems to be in "low peripheral" mode by default.
+          * These values were observed from running
+          * Raspbian instance from /proc/iomem and /sys/firmware/devicetree/base
+          *
+          * Set gpu_mem=64 so we have following memory ranges available
+          * VC GPU RAM 64MB -> 0x40000000-0x04000000 = 0x3c000000
+          *
+          * 0x00 0x00000000 0x3c000000  960MB
+          * 0x00 0x40000000 0xbc000000  3008MB
+          * 0x01 0x00000000 0x80000000  2048MB
+          * 0x01 0x80000000 0x80000000  2048MB
+          */
+        reg = < 0x00 0x00000000 0x3c000000 /* 960MB */
+                0x00 0x40000000 0xbc000000 /* 3008MB */
+                0x01 0x00000000 0x80000000 /* 2048MB */
+                0x01 0x80000000 0x80000000 /* 2048MB */ >;
 	};
 
 	reserved-memory {

--- a/src/plat/bcm2711/overlay-rpi4.dts
+++ b/src/plat/bcm2711/overlay-rpi4.dts
@@ -17,35 +17,60 @@
 		    &{/timer};
 	};
 
-	memory@0 {
-        /*
-         * See BCM2711 TRM section 1.2 and
-         * https://github.com/raspberrypi/firmware/issues/1374 for
-         * reference.
-         */
+	/*
+	 * See BCM2711 TRM section 1.2 and
+	 * https://github.com/raspberrypi/firmware/issues/1374 for
+	 * reference.
+	 *
+	 * RPi4B seems to be in "low peripheral" mode by default.
+	 * These values were observed from running
+	 * Raspbian instance from /proc/iomem and /sys/firmware/devicetree/base
+	 *
+	 * By default, the RPi 4B has 76MB reserved for the VideoCore/GPU.
+	 * So, we have following memory ranges available:
+	 *
+	 * VC GPU RAM 76MB -> 0x40000000-0x04C00000 = 0x3b400000
+	 *
+	 * 0x00 0x00000000 0x3b400000  948MB
+	 * 0x00 0x40000000 0xbc000000  3008MB
+	 * 0x01 0x00000000 0x80000000  2048MB
+	 * 0x01 0x80000000 0x80000000  2048MB
+	 *
+	 * Disjunct memory areas seem to work only
+	 * when declared in different memory DT nodes.
+	 *
+	 * If all of the declarations below are in the
+	 * same node, the kernel build system seems
+	 * to only understand the second 3008MB area
+	 * and ignores the rest.
+	 */
 
-         /* RPi4B seems to be in "low peripheral" mode by default.
-          * These values were observed from running
-          * Raspbian instance from /proc/iomem and /sys/firmware/devicetree/base
-          *
-          * Set gpu_mem=64 so we have following memory ranges available
-          * VC GPU RAM 64MB -> 0x40000000-0x04000000 = 0x3c000000
-          *
-          * 0x00 0x00000000 0x3c000000  960MB
-          * 0x00 0x40000000 0xbc000000  3008MB
-          * 0x01 0x00000000 0x80000000  2048MB
-          * 0x01 0x80000000 0x80000000  2048MB
-          */
-        reg = < 0x00 0x00000000 0x3c000000 /* 960MB */
-                0x00 0x40000000 0xbc000000 /* 3008MB */
-                0x01 0x00000000 0x80000000 /* 2048MB */
-                0x01 0x80000000 0x80000000 /* 2048MB */ >;
+	/delete-node/ memory;
+
+	memory@0 {
+		device_type = "memory";
+		reg = < 0x00000000 0x00000000 0x3b400000 >;
 	};
 
+	memory@40000000 {
+		device_type = "memory";
+		reg = < 0x00000000 0x40000000 0xbc000000 >;
+	};
+
+	memory@100000000 {
+		device_type = "memory";
+		reg = < 0x00000001 0x00000000 0x80000000
+			0x00000001 0x80000000 0x80000000 >;
+	};
+
+	/* TODO: add DMA dedicated ranges
+	 * here also?
+	 */
 	reserved-memory {
-		#address-cells = <0x01>;
+		#address-cells = <0x02>;
 		#size-cells = <0x01>;
 		ranges;
+
 		/* Keep the first page of physical memory is reserved for the initial
 		 * bootloader (e.g. armstub). It has parked the secondary cores there,
 		 * they spin until they get released. When SMP is enabled, the kernel
@@ -58,7 +83,16 @@
 		 * See also https://leiradel.github.io/2019/01/20/Raspberry-Pi-Stubs.html#armstub8s
 		 */
 		reserved-memory@0{
-			reg = <0x0 0x1000>;
+			reg = < 0x00000000 0x00000000 0x00001000 >;
+			no-map;
+		};
+
+		/* Enforce that nothing tries to
+		 * use the VideoCore memory area
+		 * by declaring it as reserved memory.
+		 */
+		reserved-memory@3c000000 {
+			reg = < 0x00000000 0x3b400000 0x04C00000 >;
 			no-map;
 		};
 	};

--- a/src/plat/bcm2711/overlay-rpi4.dts
+++ b/src/plat/bcm2711/overlay-rpi4.dts
@@ -21,4 +21,25 @@
 		/* This is configurable in the Pi's config.txt, but we use 128MiB of RAM by default. */
 		reg = <0x00 0x00000000 0x08000000>;
 	};
+
+	reserved-memory {
+		#address-cells = <0x01>;
+		#size-cells = <0x01>;
+		ranges;
+		/* Keep the first page of physical memory is reserved for the initial
+		 * bootloader (e.g. armstub). It has parked the secondary cores there,
+		 * they spin until they get released. When SMP is enabled, the kernel
+		 * will release them during boot and this memory can be reused.
+		 * However, we still have to ensure the kernel image itself is not
+		 * placed here. In non-SMP configurations, the cores must keep spinning
+		 * forever. Re-using this memory will cause the secondary cores to
+		 * execute whatever content is placed there, which likely makes them
+		 * run amok.
+		 * See also https://leiradel.github.io/2019/01/20/Raspberry-Pi-Stubs.html#armstub8s
+		 */
+		reserved-memory@0{
+			reg = <0x0 0x1000>;
+			no-map;
+		};
+	};
 };

--- a/src/plat/bcm2837/overlay-rpi3.dts
+++ b/src/plat/bcm2837/overlay-rpi3.dts
@@ -41,4 +41,14 @@
 			no-map;
 		};
 	};
+
+        soc {
+                timer@7e003000 {
+                        reg = <0x3F003000 0x1000>;
+			/* Channels 0 and 2 used by VC, so just expose 1 and
+			 * 3. Otherwise we're spammed with spurious
+			 * interrupts. */
+                        interrupts = <0x01 0x01 0x01 0x03>;
+                };
+        };
 };

--- a/tools/dts/rpi4.dts
+++ b/tools/dts/rpi4.dts
@@ -42,6 +42,11 @@
 			linux,cma-default;
 			alloc-ranges = <0x00 0x00 0x40000000>;
 		};
+
+		vc_mem {
+			size = <0xc0000000>;
+			alloc-ranges = <0x00 0x3ec00000 0xc0000000>;
+		};
 	};
 
 	thermal-zones {

--- a/tools/dts/rpi4.dts
+++ b/tools/dts/rpi4.dts
@@ -924,8 +924,6 @@
 			interrupts = <0x00 0x5d 0x04>;
 			clocks = <0x0c 0x00>;
 			status = "okay";
-			pinctrl-names = "default";
-			pinctrl-0 = <0x0d>;
 		};
 
 		spi@7e215080 {


### PR DESCRIPTION
Sometimes device trees may have differences between vanilla Linux
and SoC vendor, and the changes can be tedious to override with a
device tree overlay.

This change allows overriding the platform default dts and overlays
with a custom one.

Signed-off-by: Markku Ahvenjärvi <markkux@ssrc.tii.ae>