### PR TITLE
Add ability to expand log buffer size

### DIFF
--- a/config.cmake
+++ b/config.cmake
@@ -592,4 +592,19 @@ config_option(
     DEFAULT OFF
 )
 
+config_option(
+    KernelExpandLogBuffer ENABLE_LOG_BUFFER_EXPANSION
+    "Allow log buffer to be larger than 1 frame cap."
+    DEFAULT OFF 
+    DEPENDS KernelBenchmarks 
+)
+
+config_string(
+    KernelLogBufferSize NUM_LOG_BUFFER_FRAME
+    "Number of frame caps to be allocated for tracing buffer."
+    DEFAULT 5 
+    DEPENDS KernelExpandLogBuffer UNDEF_DISABLED
+    UNQUOTE
+)
+
 add_config_library(kernel "${configure_string}")

--- a/include/arch/arm/arch/64/mode/hardware.h
+++ b/include/arch/arm/arch/64/mode/hardware.h
@@ -208,7 +208,11 @@
 #define KDEV_BASE KERNEL_PT_BASE
 
 /* The log buffer is placed before the device region */
+#ifdef CONFIG_ENABLE_LOG_BUFFER_EXPANSION
+#define KS_LOG_PPTR (KDEV_BASE - UL_CONST(0x200000)*CONFIG_NUM_LOG_BUFFER_FRAME)
+#else
 #define KS_LOG_PPTR (KDEV_BASE - UL_CONST(0x200000))
+#endif /* CONFIG_ENABLE_LOG_BUFFER_EXPANSION */
 
 /* All PPTR addresses must be canonical to be able to be stored in caps or objects.
    Check that all UTs that are created will have valid address in the PPTR space.

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -42,7 +42,11 @@ extern bool_t ksStarted[CONFIG_MAX_NUM_TRACE_POINTS];
 extern timestamp_t ksExit;
 extern seL4_Word ksLogIndex;
 extern seL4_Word ksLogIndexFinalized;
+#ifdef CONFIG_ENABLE_LOG_BUFFER_EXPANSION
+extern paddr_t ksUserLogBuffer[CONFIG_NUM_LOG_BUFFER_FRAME];
+#else
 extern paddr_t ksUserLogBuffer;
+#endif /* CONFIG_ENABLE_LOG_BUFFER_EXPANSION */
 
 static inline void trace_point_start(word_t id)
 {
@@ -55,7 +59,11 @@ static inline void trace_point_stop(word_t id)
     benchmark_tracepoint_log_entry_t *ksLog = (benchmark_tracepoint_log_entry_t *) KS_LOG_PPTR;
     ksExit = timestamp();
 
+#ifdef CONFIG_ENABLE_LOG_BUFFER_EXPANSION
+    if (likely(ksUserLogBuffer[0] != 0)) {
+#else
     if (likely(ksUserLogBuffer != 0)) {
+#endif /* CONFIG_ENABLE_LOG_BUFFER_EXPANSION */
         if (likely(ksStarted[id])) {
             ksStarted[id] = false;
             if (likely(ksLogIndex < MAX_LOG_SIZE)) {

--- a/include/kernel/vspace.h
+++ b/include/kernel/vspace.h
@@ -9,6 +9,10 @@
 #include <arch/kernel/vspace.h>
 
 #ifdef CONFIG_KERNEL_LOG_BUFFER
+#ifdef CONFIG_ENABLE_LOG_BUFFER_EXPANSION
+exception_t benchmark_arch_map_logBuffer(word_t frame_cptr, seL4_Uint32 frame_index);
+#else
 exception_t benchmark_arch_map_logBuffer(word_t frame_cptr);
+#endif /* CONFIG_ENABLE_LOG_BUFFER_EXPANSION */
 #endif /* CONFIG_KERNEL_LOG_BUFFER */
 

--- a/include/model/statedata.h
+++ b/include/model/statedata.h
@@ -121,7 +121,11 @@ extern char ksIdleThreadSC[CONFIG_MAX_NUM_NODES][BIT(seL4_MinSchedContextBits)];
 #endif
 
 #ifdef CONFIG_KERNEL_LOG_BUFFER
+#ifdef CONFIG_ENABLE_LOG_BUFFER_EXPANSION
+extern paddr_t ksUserLogBuffer[CONFIG_NUM_LOG_BUFFER_FRAME];
+#else
 extern paddr_t ksUserLogBuffer;
+#endif /* CONFIG_ENABLE_LOG_BUFFER_EXPANSION */
 #endif /* CONFIG_KERNEL_LOG_BUFFER */
 
 #define SchedulerAction_ResumeCurrentThread ((tcb_t*)0)

--- a/libsel4/arch_include/arm/sel4/arch/syscalls.h
+++ b/libsel4/arch_include/arm/sel4/arch/syscalls.h
@@ -690,6 +690,24 @@ LIBSEL4_INLINE_FUNC seL4_Word seL4_BenchmarkFinalizeLog(void)
     return (seL4_Word) index_ret;
 }
 
+#ifdef CONFIG_ENABLE_LOG_BUFFER_EXPANSION
+LIBSEL4_INLINE_FUNC seL4_Error seL4_BenchmarkSetLargeLogBuffer(seL4_Word frame_cptr, seL4_MessageInfo_t msgInfo)
+{
+    seL4_MessageInfo_t info;
+     /* Load beginning of the message into registers. */
+    seL4_Word msg0 = seL4_GetMR(0);
+    seL4_Word msg1 = seL4_GetMR(1);
+    seL4_Word msg2 = seL4_GetMR(2);
+    seL4_Word msg3 = seL4_GetMR(3);
+
+    arm_sys_send_recv(seL4_SysBenchmarkSetLogBuffer, frame_cptr, &frame_cptr, msgInfo.words[0], &info.words[0], 
+                    &msg0, &msg1, &msg2, &msg3, 0);
+
+        
+    return (seL4_Error) frame_cptr;
+}
+#endif /* CONFIG_ENABLE_LOG_BUFFER_EXPANSION */
+
 LIBSEL4_INLINE_FUNC seL4_Error seL4_BenchmarkSetLogBuffer(seL4_Word frame_cptr)
 {
     seL4_Word unused0 = 0;

--- a/libsel4/include/sel4/syscalls.h
+++ b/libsel4/include/sel4/syscalls.h
@@ -210,6 +210,24 @@ seL4_BenchmarkResetLog(void);
 LIBSEL4_INLINE_FUNC seL4_Word
 seL4_BenchmarkFinalizeLog(void);
 
+#ifdef CONFIG_ENABLE_LOG_BUFFER_EXPANSION
+/**
+ * @xmlonly <manual name="Set Large Log Buffer" label="seL4_BenchmarkSetLargeLogBuffer"/> @endxmlonly
+ * @brief Set log buffer.
+ *
+ * Provide a large frame object for the kernel to use as a log-buffer and the index of the frame among others in the buffer.
+ * The object must not be device memory, and must be seL4_LargePageBits in size.
+ *
+ * @param[in] frame_cptr A capability pointer to a user allocated frame of seL4_LargePage size.
+ * @param[in] msgInfo the index of current frame capability in total buffer.
+ * @return A `seL4_IllegalOperation` error if `frame_cptr` or `msgInfo` is not valid and couldn't set the buffer.
+ *
+ */
+
+LIBSEL4_INLINE_FUNC seL4_Error
+seL4_BenchmarkSetLargeLogBuffer(seL4_Word frame_cptr, seL4_MessageInfo_t msgInfo);
+#endif /* CONFIG_ENABLE_LOG_BUFFER_EXPANSION */
+
 /**
  * @xmlonly <manual name="Set Log Buffer" label="sel4_benchmarksetlogbuffer"/> @endxmlonly
  * @brief Set log buffer.

--- a/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
@@ -243,8 +243,13 @@ SEL4_SIZE_SANITY(seL4_PUDEntryBits, seL4_PUDIndexBits, seL4_PUDBits);
 #endif
 
 #ifdef CONFIG_ENABLE_BENCHMARKS
+#ifdef CONFIG_ENABLE_LOG_BUFFER_EXPANSION
+/* size of kernel log buffer in bytes */
+#define seL4_LogBufferSize (LIBSEL4_BIT(21)*CONFIG_NUM_LOG_BUFFER_FRAME)
+#else
 /* size of kernel log buffer in bytes */
 #define seL4_LogBufferSize (LIBSEL4_BIT(20))
+#endif /* CONFIG_ENABLE_LOG_BUFFER_EXPANSION */
 #endif /* CONFIG_ENABLE_BENCHMARKS */
 
 #define seL4_FastMessageRegisters 4

--- a/src/arch/arm/64/kernel/vspace.c
+++ b/src/arch/arm/64/kernel/vspace.c
@@ -2521,15 +2521,15 @@ void Arch_userStackTrace(tcb_t *tptr)
 #endif /* CONFIG_PRINTING */
 
 #if defined(CONFIG_KERNEL_LOG_BUFFER)
+#ifdef CONFIG_ENABLE_LOG_BUFFER_EXPANSION
+exception_t benchmark_arch_map_logBuffer(word_t frame_cptr, seL4_Uint32 frameIndex)
+#else
 exception_t benchmark_arch_map_logBuffer(word_t frame_cptr)
+#endif /* CONFIG_ENABLE_LOG_BUFFER_EXPANSION */
 {
     lookupCapAndSlot_ret_t lu_ret;
     vm_page_size_t frameSize;
     pptr_t  frame_pptr;
-
-#ifdef CONFIG_ENABLE_LOG_BUFFER_EXPANSION
-    static int frameIndex = 0;
-#endif /* CONFIG_ENABLE_LOG_BUFFER_EXPANSION */
 
     /* faulting section */
     lu_ret = lookupCapAndSlot(NODE_STATE(ksCurThread), frame_cptr);
@@ -2592,7 +2592,6 @@ exception_t benchmark_arch_map_logBuffer(word_t frame_cptr)
 
 #ifdef CONFIG_ENABLE_LOG_BUFFER_EXPANSION
     cleanByVA_PoU((vptr_t)(armKSGlobalLogPDE + frameIndex), addrFromKPPtr((armKSGlobalLogPDE + frameIndex)));
-    frameIndex++;
 #else
     cleanByVA_PoU((vptr_t)(armKSGlobalLogPDE), addrFromKPPtr((armKSGlobalLogPDE)));
 #endif /* CONFIG_ENABLE_LOG_BUFFER_EXPANSION */

--- a/src/arch/arm/64/model/statedata.c
+++ b/src/arch/arm/64/model/statedata.c
@@ -90,11 +90,16 @@ pde_t armKSGlobalKernelPDs[BIT(PUD_INDEX_BITS)][BIT(PD_INDEX_BITS)] ALIGN_BSS(BI
 pte_t armKSGlobalKernelPT[BIT(PT_INDEX_BITS)] ALIGN_BSS(BIT(seL4_PageTableBits));
 
 #ifdef CONFIG_KERNEL_LOG_BUFFER
+#ifdef CONFIG_ENABLE_LOG_BUFFER_EXPANSION
+/* Backtracking from the end of PD */
+pde_t *armKSGlobalLogPDE = &armKSGlobalKernelPDs[BIT(PUD_INDEX_BITS) - 1][BIT(PD_INDEX_BITS) - 1 - CONFIG_NUM_LOG_BUFFER_FRAME];
+#else
 pde_t *armKSGlobalLogPDE = &armKSGlobalKernelPDs[BIT(PUD_INDEX_BITS) - 1][BIT(PD_INDEX_BITS) - 2];
 compile_assert(log_pude_is_correct_preallocated_pude,
                GET_PUD_INDEX(KS_LOG_PPTR) == BIT(PUD_INDEX_BITS) - 1);
 compile_assert(log_pde_is_correct_preallocated_pde,
                GET_PD_INDEX(KS_LOG_PPTR) == BIT(PD_INDEX_BITS) - 2);
+#endif /* CONFIG_ENABLE_LOG_BUFFER_EXPANSION */
 #endif
 
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT

--- a/src/benchmark/benchmark.c
+++ b/src/benchmark/benchmark.c
@@ -32,7 +32,11 @@ exception_t handle_SysBenchmarkFlushCaches(void)
 exception_t handle_SysBenchmarkResetLog(void)
 {
 #ifdef CONFIG_KERNEL_LOG_BUFFER
+#ifdef CONFIG_ENABLE_LOG_BUFFER_EXPANSION
+    if (ksUserLogBuffer[0] == 0) {
+#else
     if (ksUserLogBuffer == 0) {
+#endif /* CONFIG_ENABLE_LOG_BUFFER_EXPANSION */
         userError("A user-level buffer has to be set before resetting benchmark.\
                 Use seL4_BenchmarkSetLogBuffer\n");
         setRegister(NODE_STATE(ksCurThread), capRegister, seL4_IllegalOperation);

--- a/src/benchmark/benchmark_track.c
+++ b/src/benchmark/benchmark_track.c
@@ -20,7 +20,12 @@ void benchmark_track_exit(void)
     timestamp_t ksExit = timestamp();
     benchmark_track_kernel_entry_t *ksLog = (benchmark_track_kernel_entry_t *) KS_LOG_PPTR;
 
+
+#ifdef CONFIG_ENABLE_LOG_BUFFER_EXPANSION
+    if (likely(ksUserLogBuffer[0] != 0)) {
+#else
     if (likely(ksUserLogBuffer != 0)) {
+#endif /* CONFIG_ENABLE_LOG_BUFFER_EXPANSION */
         /* If Log buffer is filled, do nothing */
         if (likely(ksLogIndex < MAX_LOG_SIZE)) {
             duration = ksExit - ksEnter;

--- a/src/model/statedata.c
+++ b/src/model/statedata.c
@@ -110,5 +110,9 @@ kernel_entry_t ksKernelEntry;
 #endif /* DEBUG */
 
 #ifdef CONFIG_KERNEL_LOG_BUFFER
+#ifdef CONFIG_ENABLE_LOG_BUFFER_EXPANSION
+paddr_t ksUserLogBuffer[CONFIG_NUM_LOG_BUFFER_FRAME];
+#else
 paddr_t ksUserLogBuffer;
+#endif /* CONFIG_ENABLE_LOG_BUFFER_EXPANSION */
 #endif /* CONFIG_KERNEL_LOG_BUFFER */


### PR DESCRIPTION
How can the buffer be expanded?

1 Remove or expand the constant macro that limits the index of logging data.
- Modify the macro to be equal to the memory size equal to which is allocated for logging.

2 Expand the internal buffer.
- Move the start address of the "internal buffer" further back before the device region.
- Because the "internal buffer" is in the kernel page table region, it is necessary to allocate it with more pages.

3 Modify "seL4_BenchmarkSetLogBuffer"
- After 1 and 2, the start address of the logging region has now been set, but the memory allocated with frame capabilities are not mapped to logging region.
- The API is modified to map multiple frame capabilities to the adjacent memory area of the "internal buffer".

4 Create a compilation flag to keep the stock code.