### PR TITLE
Add ability to expand the kernel log buffer with compilation flags

### DIFF
--- a/config.cmake
+++ b/config.cmake
@@ -592,4 +592,19 @@ config_option(
     DEFAULT OFF
 )
 
+config_option(
+    KernelExpandLogBuffer ENABLE_LOG_BUFFER_EXPANSION
+    "Allow log buffer to be larger than 1 frame cap."
+    DEFAULT OFF 
+    DEPENDS KernelBenchmarks 
+)
+
+config_string(
+    KernelLogBufferSize NUM_LOG_BUFFER_FRAME
+    "Number of frame caps to be allocated for tracing buffer."
+    DEFAULT 5 
+    DEPENDS KernelExpandLogBuffer UNDEF_DISABLED
+    UNQUOTE
+)
+
 add_config_library(kernel "${configure_string}")

--- a/config.cmake
+++ b/config.cmake
@@ -393,6 +393,14 @@ config_option(
 )
 
 config_option(
+    KernelMemDebugPrinting KERNEL_MEM_DEBUG_PRINTING
+    "Print more verbose output about free memory init and creation of untyped regions during bootup."
+    DEFAULT OFF
+    DEPENDS "KernelPrinting"
+    DEFAULT_DISABLED OFF
+)
+
+config_option(
     KernelInvocationReportErrorIPC KERNEL_INVOCATION_REPORT_ERROR_IPC
     "Allows the kernel to write the userError to the IPC buffer"
     DEFAULT OFF

--- a/include/api/debug.h
+++ b/include/api/debug.h
@@ -77,7 +77,7 @@ static inline void debug_printUserState(void)
 
 static inline void debug_printTCB(tcb_t *tcb)
 {
-    printf("%40s\t", TCB_PTR_DEBUG_PTR(tcb)->tcbName);
+    printf("%lx %40s\t", (unsigned long int)tcb, TCB_PTR_DEBUG_PTR(tcb)->tcbName);
     char *state;
     switch (thread_state_get_tsType(tcb->tcbState)) {
     case ThreadState_Inactive:

--- a/include/arch/arm/arch/64/mode/hardware.h
+++ b/include/arch/arm/arch/64/mode/hardware.h
@@ -208,7 +208,11 @@
 #define KDEV_BASE KERNEL_PT_BASE
 
 /* The log buffer is placed before the device region */
+#ifdef CONFIG_ENABLE_LOG_BUFFER_EXPANSION
+#define KS_LOG_PPTR (KDEV_BASE - UL_CONST(0x200000)*CONFIG_NUM_LOG_BUFFER_FRAME)
+#else
 #define KS_LOG_PPTR (KDEV_BASE - UL_CONST(0x200000))
+#endif /* CONFIG_ENABLE_LOG_BUFFER_EXPANSION */
 
 /* All PPTR addresses must be canonical to be able to be stored in caps or objects.
    Check that all UTs that are created will have valid address in the PPTR space.

--- a/include/arch/arm/armv/armv8-a/64/armv/vcpu.h
+++ b/include/arch/arm/armv/armv8-a/64/armv/vcpu.h
@@ -19,7 +19,7 @@
 #define HCR_COMMON ( HCR_VM | HCR_RW | HCR_AMO | HCR_IMO | HCR_FMO )
 #else
 /* Trap WFI/WFE/SMC and override CPSR.AIF */
-#define HCR_COMMON ( HCR_TWI | HCR_TWE | HCR_VM | HCR_RW | HCR_AMO | HCR_IMO | HCR_FMO )
+#define HCR_COMMON ( HCR_TWI | /*HCR_TWE |*/ HCR_VM | HCR_RW | HCR_AMO | HCR_IMO | HCR_FMO )
 #endif
 
 /* Allow native tasks to run at EL0, but restrict access */
@@ -46,6 +46,7 @@
 #define SCTLR_DEFAULT      SCTLR_EL1_NATIVE
 
 #define UNKNOWN_FAULT       0x2000000
+#define ESR_EC_WFX          0x1         /* Trap WFI and WFE */
 #define ESR_EC_TFP          0x7         /* Trap instructions that access FPU registers */
 #define ESR_EC_CPACR        0x18        /* Trap access to CPACR                        */
 #define ESR_EC(x)           (((x) & 0xfc000000) >> 26)
@@ -655,6 +656,13 @@ static inline bool_t armv_handleVCPUFault(word_t hsr)
         return true;
     }
 #endif
+    if (ESR_EC(hsr) == ESR_EC_WFX) {
+        if ((hsr & 1) == 0) {
+            /* WFI */
+            handleSyscall(SysYield);
+            return true;
+        }
+    }
 
     if (hsr == UNKNOWN_FAULT) {
         handleUserLevelFault(getESR(), 0);

--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -42,7 +42,11 @@ extern bool_t ksStarted[CONFIG_MAX_NUM_TRACE_POINTS];
 extern timestamp_t ksExit;
 extern seL4_Word ksLogIndex;
 extern seL4_Word ksLogIndexFinalized;
+#ifdef CONFIG_ENABLE_LOG_BUFFER_EXPANSION
+extern paddr_t ksUserLogBuffer[CONFIG_NUM_LOG_BUFFER_FRAME];
+#else
 extern paddr_t ksUserLogBuffer;
+#endif /* CONFIG_ENABLE_LOG_BUFFER_EXPANSION */
 
 static inline void trace_point_start(word_t id)
 {
@@ -55,7 +59,11 @@ static inline void trace_point_stop(word_t id)
     benchmark_tracepoint_log_entry_t *ksLog = (benchmark_tracepoint_log_entry_t *) KS_LOG_PPTR;
     ksExit = timestamp();
 
+#ifdef CONFIG_ENABLE_LOG_BUFFER_EXPANSION
+    if (likely(ksUserLogBuffer[0] != 0)) {
+#else
     if (likely(ksUserLogBuffer != 0)) {
+#endif /* CONFIG_ENABLE_LOG_BUFFER_EXPANSION */
         if (likely(ksStarted[id])) {
             ksStarted[id] = false;
             if (likely(ksLogIndex < MAX_LOG_SIZE)) {

--- a/include/kernel/vspace.h
+++ b/include/kernel/vspace.h
@@ -9,6 +9,10 @@
 #include <arch/kernel/vspace.h>
 
 #ifdef CONFIG_KERNEL_LOG_BUFFER
+#ifdef CONFIG_ENABLE_LOG_BUFFER_EXPANSION
+exception_t benchmark_arch_map_logBuffer(word_t frame_cptr, seL4_Uint32 frame_index);
+#else
 exception_t benchmark_arch_map_logBuffer(word_t frame_cptr);
+#endif /* CONFIG_ENABLE_LOG_BUFFER_EXPANSION */
 #endif /* CONFIG_KERNEL_LOG_BUFFER */
 

--- a/include/model/statedata.h
+++ b/include/model/statedata.h
@@ -121,7 +121,11 @@ extern char ksIdleThreadSC[CONFIG_MAX_NUM_NODES][BIT(seL4_MinSchedContextBits)];
 #endif
 
 #ifdef CONFIG_KERNEL_LOG_BUFFER
+#ifdef CONFIG_ENABLE_LOG_BUFFER_EXPANSION
+extern paddr_t ksUserLogBuffer[CONFIG_NUM_LOG_BUFFER_FRAME];
+#else
 extern paddr_t ksUserLogBuffer;
+#endif /* CONFIG_ENABLE_LOG_BUFFER_EXPANSION */
 #endif /* CONFIG_KERNEL_LOG_BUFFER */
 
 #define SchedulerAction_ResumeCurrentThread ((tcb_t*)0)

--- a/libsel4/arch_include/arm/sel4/arch/syscalls.h
+++ b/libsel4/arch_include/arm/sel4/arch/syscalls.h
@@ -690,6 +690,24 @@ LIBSEL4_INLINE_FUNC seL4_Word seL4_BenchmarkFinalizeLog(void)
     return (seL4_Word) index_ret;
 }
 
+#ifdef CONFIG_ENABLE_LOG_BUFFER_EXPANSION
+LIBSEL4_INLINE_FUNC seL4_Error seL4_BenchmarkSetLargeLogBuffer(seL4_Word frame_cptr, seL4_MessageInfo_t msgInfo)
+{
+    seL4_MessageInfo_t info;
+     /* Load beginning of the message into registers. */
+    seL4_Word msg0 = seL4_GetMR(0);
+    seL4_Word msg1 = seL4_GetMR(1);
+    seL4_Word msg2 = seL4_GetMR(2);
+    seL4_Word msg3 = seL4_GetMR(3);
+
+    arm_sys_send_recv(seL4_SysBenchmarkSetLogBuffer, frame_cptr, &frame_cptr, msgInfo.words[0], &info.words[0], 
+                    &msg0, &msg1, &msg2, &msg3, 0);
+
+        
+    return (seL4_Error) frame_cptr;
+}
+#endif /* CONFIG_ENABLE_LOG_BUFFER_EXPANSION */
+
 LIBSEL4_INLINE_FUNC seL4_Error seL4_BenchmarkSetLogBuffer(seL4_Word frame_cptr)
 {
     seL4_Word unused0 = 0;

--- a/libsel4/include/sel4/benchmark_track_types.h
+++ b/libsel4/include/sel4/benchmark_track_types.h
@@ -27,6 +27,7 @@ typedef enum {
 #ifdef CONFIG_ARCH_X86
     Entry_VMExit,
 #endif
+    Entry_Switch,
 } entry_type_t;
 
 /**
@@ -35,7 +36,7 @@ typedef enum {
  * Encapsulates useful info about the cause of the kernel entry
  */
 typedef struct SEL4_PACKED kernel_entry {
-    seL4_Word path: 3;
+    seL4_Word path: 4;
     union {
         struct {
             seL4_Word core: 3;
@@ -48,6 +49,7 @@ typedef struct SEL4_PACKED kernel_entry {
             seL4_Word is_fastpath: 1;
             seL4_Word invocation_tag: 19;
         };
+        void *next;
     };
 } kernel_entry_t;
 

--- a/libsel4/include/sel4/syscalls.h
+++ b/libsel4/include/sel4/syscalls.h
@@ -210,6 +210,24 @@ seL4_BenchmarkResetLog(void);
 LIBSEL4_INLINE_FUNC seL4_Word
 seL4_BenchmarkFinalizeLog(void);
 
+#ifdef CONFIG_ENABLE_LOG_BUFFER_EXPANSION
+/**
+ * @xmlonly <manual name="Set Large Log Buffer" label="seL4_BenchmarkSetLargeLogBuffer"/> @endxmlonly
+ * @brief Set log buffer.
+ *
+ * Provide a large frame object for the kernel to use as a log-buffer and the index of the frame among others in the buffer.
+ * The object must not be device memory, and must be seL4_LargePageBits in size.
+ *
+ * @param[in] frame_cptr A capability pointer to a user allocated frame of seL4_LargePage size.
+ * @param[in] msgInfo the index of current frame capability in total buffer.
+ * @return A `seL4_IllegalOperation` error if `frame_cptr` or `msgInfo` is not valid and couldn't set the buffer.
+ *
+ */
+
+LIBSEL4_INLINE_FUNC seL4_Error
+seL4_BenchmarkSetLargeLogBuffer(seL4_Word frame_cptr, seL4_MessageInfo_t msgInfo);
+#endif /* CONFIG_ENABLE_LOG_BUFFER_EXPANSION */
+
 /**
  * @xmlonly <manual name="Set Log Buffer" label="sel4_benchmarksetlogbuffer"/> @endxmlonly
  * @brief Set log buffer.

--- a/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
@@ -243,8 +243,13 @@ SEL4_SIZE_SANITY(seL4_PUDEntryBits, seL4_PUDIndexBits, seL4_PUDBits);
 #endif
 
 #ifdef CONFIG_ENABLE_BENCHMARKS
+#ifdef CONFIG_ENABLE_LOG_BUFFER_EXPANSION
+/* size of kernel log buffer in bytes */
+#define seL4_LogBufferSize (LIBSEL4_BIT(21)*CONFIG_NUM_LOG_BUFFER_FRAME)
+#else
 /* size of kernel log buffer in bytes */
 #define seL4_LogBufferSize (LIBSEL4_BIT(20))
+#endif /* CONFIG_ENABLE_LOG_BUFFER_EXPANSION */
 #endif /* CONFIG_ENABLE_BENCHMARKS */
 
 #define seL4_FastMessageRegisters 4

--- a/src/arch/arm/64/kernel/vspace.c
+++ b/src/arch/arm/64/kernel/vspace.c
@@ -2521,7 +2521,11 @@ void Arch_userStackTrace(tcb_t *tptr)
 #endif /* CONFIG_PRINTING */
 
 #if defined(CONFIG_KERNEL_LOG_BUFFER)
+#ifdef CONFIG_ENABLE_LOG_BUFFER_EXPANSION
+exception_t benchmark_arch_map_logBuffer(word_t frame_cptr, seL4_Uint32 frameIndex)
+#else
 exception_t benchmark_arch_map_logBuffer(word_t frame_cptr)
+#endif /* CONFIG_ENABLE_LOG_BUFFER_EXPANSION */
 {
     lookupCapAndSlot_ret_t lu_ret;
     vm_page_size_t frameSize;
@@ -2555,22 +2559,42 @@ exception_t benchmark_arch_map_logBuffer(word_t frame_cptr)
 
     frame_pptr = cap_frame_cap_get_capFBasePtr(lu_ret.cap);
 
+#ifdef CONFIG_ENABLE_LOG_BUFFER_EXPANSION
+    ksUserLogBuffer[frameIndex] = pptr_to_paddr((void *) frame_pptr);
+#else
     ksUserLogBuffer = pptr_to_paddr((void *) frame_pptr);
+#endif /* CONFIG_ENABLE_LOG_BUFFER_EXPANSION */
 
-    *armKSGlobalLogPDE = pde_pde_large_new(
+
+#ifdef CONFIG_ENABLE_LOG_BUFFER_EXPANSION
+    *(armKSGlobalLogPDE + frameIndex)  = pde_pde_large_new(
+#else
+    *armKSGlobalLogPDE  = pde_pde_large_new(
+#endif /* CONFIG_ENABLE_LOG_BUFFER_EXPANSION */
+
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
                              0, // XN
 #else
                              1, // UXN
 #endif
+
+
+#ifdef CONFIG_ENABLE_LOG_BUFFER_EXPANSION
+                             ksUserLogBuffer[frameIndex],
+#else
                              ksUserLogBuffer,
+#endif /* CONFIG_ENABLE_LOG_BUFFER_EXPANSION */
                              0,                         /* global */
                              1,                         /* access flag */
                              SMP_TERNARY(SMP_SHARE, 0), /* Inner-shareable if SMP enabled, otherwise unshared */
                              0,                         /* VMKernelOnly */
                              NORMAL_WT);
 
-    cleanByVA_PoU((vptr_t)armKSGlobalLogPDE, addrFromKPPtr(armKSGlobalLogPDE));
+#ifdef CONFIG_ENABLE_LOG_BUFFER_EXPANSION
+    cleanByVA_PoU((vptr_t)(armKSGlobalLogPDE + frameIndex), addrFromKPPtr((armKSGlobalLogPDE + frameIndex)));
+#else
+    cleanByVA_PoU((vptr_t)(armKSGlobalLogPDE), addrFromKPPtr((armKSGlobalLogPDE)));
+#endif /* CONFIG_ENABLE_LOG_BUFFER_EXPANSION */
     invalidateTranslationSingle(KS_LOG_PPTR);
     return EXCEPTION_NONE;
 }

--- a/src/arch/arm/64/model/statedata.c
+++ b/src/arch/arm/64/model/statedata.c
@@ -90,11 +90,16 @@ pde_t armKSGlobalKernelPDs[BIT(PUD_INDEX_BITS)][BIT(PD_INDEX_BITS)] ALIGN_BSS(BI
 pte_t armKSGlobalKernelPT[BIT(PT_INDEX_BITS)] ALIGN_BSS(BIT(seL4_PageTableBits));
 
 #ifdef CONFIG_KERNEL_LOG_BUFFER
+#ifdef CONFIG_ENABLE_LOG_BUFFER_EXPANSION
+/* Backtracking from the end of PD */
+pde_t *armKSGlobalLogPDE = &armKSGlobalKernelPDs[BIT(PUD_INDEX_BITS) - 1][BIT(PD_INDEX_BITS) - 1 - CONFIG_NUM_LOG_BUFFER_FRAME];
+#else
 pde_t *armKSGlobalLogPDE = &armKSGlobalKernelPDs[BIT(PUD_INDEX_BITS) - 1][BIT(PD_INDEX_BITS) - 2];
 compile_assert(log_pude_is_correct_preallocated_pude,
                GET_PUD_INDEX(KS_LOG_PPTR) == BIT(PUD_INDEX_BITS) - 1);
 compile_assert(log_pde_is_correct_preallocated_pde,
                GET_PD_INDEX(KS_LOG_PPTR) == BIT(PD_INDEX_BITS) - 2);
+#endif /* CONFIG_ENABLE_LOG_BUFFER_EXPANSION */
 #endif
 
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT

--- a/src/benchmark/benchmark.c
+++ b/src/benchmark/benchmark.c
@@ -32,7 +32,11 @@ exception_t handle_SysBenchmarkFlushCaches(void)
 exception_t handle_SysBenchmarkResetLog(void)
 {
 #ifdef CONFIG_KERNEL_LOG_BUFFER
+#ifdef CONFIG_ENABLE_LOG_BUFFER_EXPANSION
+    if (ksUserLogBuffer[0] == 0) {
+#else
     if (ksUserLogBuffer == 0) {
+#endif /* CONFIG_ENABLE_LOG_BUFFER_EXPANSION */
         userError("A user-level buffer has to be set before resetting benchmark.\
                 Use seL4_BenchmarkSetLogBuffer\n");
         setRegister(NODE_STATE(ksCurThread), capRegister, seL4_IllegalOperation);
@@ -75,8 +79,30 @@ exception_t handle_SysBenchmarkFinalizeLog(void)
 #ifdef CONFIG_KERNEL_LOG_BUFFER
 exception_t handle_SysBenchmarkSetLogBuffer(void)
 {
+
     word_t cptr_userFrame = getRegister(NODE_STATE(ksCurThread), capRegister);
+#ifdef CONFIG_ENABLE_LOG_BUFFER_EXPANSION
+    seL4_MessageInfo_t info = messageInfoFromWord(getRegister(NODE_STATE(ksCurThread), msgInfoRegister));
+    seL4_Uint32 len = seL4_MessageInfo_get_length(info);
+    seL4_Uint32 frameIndex = 0;
+    if (len == 1) {
+        frameIndex = (seL4_Uint32)getRegister(NODE_STATE(ksCurThread), msgRegisters[0]); 
+        if (frameIndex >= CONFIG_NUM_LOG_BUFFER_FRAME) {
+            userError("SysBenchmarkSetLogBuffer: The index of input frame exceeds buffer size.");
+            setRegister(NODE_STATE(ksCurThread), capRegister, seL4_IllegalOperation);
+            return EXCEPTION_SYSCALL_ERROR;
+        } 
+    } 
+    else {
+        userError("SysBenchmarkSetLogBuffer: Cannot read the index of the input frame.");
+        setRegister(NODE_STATE(ksCurThread), capRegister, seL4_IllegalOperation);
+        return EXCEPTION_SYSCALL_ERROR;
+    }
+    if (benchmark_arch_map_logBuffer(cptr_userFrame, frameIndex) != EXCEPTION_NONE) {
+#else 
+
     if (benchmark_arch_map_logBuffer(cptr_userFrame) != EXCEPTION_NONE) {
+#endif /* CONFIG_ENABLE_LOG_BUFFER_EXPANSION */
         setRegister(NODE_STATE(ksCurThread), capRegister, seL4_IllegalOperation);
         return EXCEPTION_SYSCALL_ERROR;
     }

--- a/src/benchmark/benchmark_track.c
+++ b/src/benchmark/benchmark_track.c
@@ -20,7 +20,12 @@ void benchmark_track_exit(void)
     timestamp_t ksExit = timestamp();
     benchmark_track_kernel_entry_t *ksLog = (benchmark_track_kernel_entry_t *) KS_LOG_PPTR;
 
+
+#ifdef CONFIG_ENABLE_LOG_BUFFER_EXPANSION
+    if (likely(ksUserLogBuffer[0] != 0)) {
+#else
     if (likely(ksUserLogBuffer != 0)) {
+#endif /* CONFIG_ENABLE_LOG_BUFFER_EXPANSION */
         /* If Log buffer is filled, do nothing */
         if (likely(ksLogIndex < MAX_LOG_SIZE)) {
             duration = ksExit - ksEnter;

--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -649,6 +649,13 @@ BOOT_CODE static bool_t create_untypeds_for_region(
             if (!provide_untyped_cap(root_cnode_cap, device_memory, reg.start, size_bits, first_untyped_slot)) {
                 return false;
             }
+#ifdef CONFIG_KERNEL_MEM_DEBUG_PRINTING
+            printf("  [%"SEL4_PRIx_word"..%"SEL4_PRIx_word"] (%s), size 0x%lx\n",
+                reg.start,
+                reg.start + BIT(size_bits),
+                device_memory ? "device" : "memory",
+                BIT(size_bits));
+#endif
         }
         reg.start += BIT(size_bits);
     }
@@ -660,6 +667,9 @@ BOOT_CODE bool_t create_untypeds(cap_t root_cnode_cap,
 {
     seL4_SlotPos first_untyped_slot = ndks_boot.slot_pos_cur;
 
+#ifdef CONFIG_KERNEL_MEM_DEBUG_PRINTING
+    printf("Creating untyped regions: \n");
+#endif
     paddr_t start = 0;
     for (word_t i = 0; i < ndks_boot.resv_count; i++) {
         if (start < ndks_boot.reserved[i].start) {
@@ -934,6 +944,20 @@ BOOT_CODE bool_t init_freemem(word_t n_available, const p_region_t *available,
             };
             /* Leave the before leftover in current slot i. */
             ndks_boot.freemem[i].end = start;
+#ifdef CONFIG_KERNEL_MEM_DEBUG_PRINTING
+            word_t num_remaining_freemem = 0;
+            for (word_t i = 0; i < ARRAY_SIZE(ndks_boot.freemem) - 1; i++) {
+                if (!is_reg_empty(ndks_boot.freemem[i])) num_remaining_freemem++;
+            }
+
+            printf("remaining freemem regions: %"SEL4_PRIu_word"\n", num_remaining_freemem);
+
+            for (word_t i = 0; i < ARRAY_SIZE(ndks_boot.freemem) - 1; i++) {
+                if (!is_reg_empty(ndks_boot.freemem[i])) {
+                    printf("  [%"SEL4_PRIx_word"..%"SEL4_PRIx_word"]\n", ndks_boot.freemem[i].start, ndks_boot.freemem[i].end);
+                }
+            }
+#endif
             /* Regions i and (i + 1) are now well defined, ordered, disjoint,
              * and unallocated, so we can return successfully. */
             return true;

--- a/src/kernel/thread.c
+++ b/src/kernel/thread.c
@@ -447,6 +447,11 @@ void switchToThread(tcb_t *thread)
     assert(refill_ready(thread->tcbSchedContext));
 #endif
 
+#ifdef CONFIG_BENCHMARK_TRACK_KERNEL_ENTRIES
+    ksKernelEntry.path = Entry_Switch;
+    ksKernelEntry.next = thread;
+#endif
+
 #ifdef CONFIG_BENCHMARK_TRACK_UTILISATION
     benchmark_utilisation_switch(NODE_STATE(ksCurThread), thread);
 #endif

--- a/src/model/statedata.c
+++ b/src/model/statedata.c
@@ -110,5 +110,9 @@ kernel_entry_t ksKernelEntry;
 #endif /* DEBUG */
 
 #ifdef CONFIG_KERNEL_LOG_BUFFER
+#ifdef CONFIG_ENABLE_LOG_BUFFER_EXPANSION
+paddr_t ksUserLogBuffer[CONFIG_NUM_LOG_BUFFER_FRAME];
+#else
 paddr_t ksUserLogBuffer;
+#endif /* CONFIG_ENABLE_LOG_BUFFER_EXPANSION */
 #endif /* CONFIG_KERNEL_LOG_BUFFER */

--- a/tools/hardware/utils/memory.py
+++ b/tools/hardware/utils/memory.py
@@ -87,7 +87,7 @@ def get_physical_memory(tree: FdtParser, config: Config) -> List[Region]:
     ''' returns a list of regions representing physical memory as used by the kernel '''
     regions = merge_memory_regions(get_memory_regions(tree))
     reserved = parse_reserved_regions(tree.get_path('/reserved-memory'))
-    regions = reserve_regions(regions, reserved)
+    regions = reserve_regions(regions, set(reserved))
     regions, extra_reserved, physBase = config.align_memory(regions)
 
     return regions, reserved.union(extra_reserved), physBase


### PR DESCRIPTION
1 Remove or expand the constant macro that limits the index of logging data.
- Modify the macro to be equal to the memory size equal to which is allocated for logging.

2 Expand the internal buffer.
- Move the start address of the "internal buffer" further back before the device region.
- Because the "internal buffer" is in the kernel page table region, it is necessary to allocate it with more pages.

3 Implement "seL4_BenchmarkSetLargeLogBuffer"based on "seL4_BenchmarkSetLogBuffer"
- After 1 and 2, the start address of the logging region has now been set, but the memory allocated with frame capabilities are not mapped to logging region.
- The new API is created to map each frame capability with its correspoding index to the "internal buffer".